### PR TITLE
Specified lua version in includes

### DIFF
--- a/snis_server.c
+++ b/snis_server.c
@@ -39,9 +39,9 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <limits.h>
-#include <lua.h>
-#include "lualib.h"
-#include "lauxlib.h"
+#include <lua5.2/lua.h>
+#include <lua5.2/lualib.h>
+#include <lua5.2/lauxlib.h>
 
 #include "ssgl/ssgl.h"
 #include "space-part.h"


### PR DESCRIPTION
Fix compilation on distributions that do not symlink latest lua version to /usr/include/lua
