### PR TITLE
Use the POSIX netinet headers.

### DIFF
--- a/snis_client.c
+++ b/snis_client.c
@@ -49,12 +49,8 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <assert.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-#include <linux/tcp.h>
-#else
 #include <netinet/tcp.h>
 #include <netinet/in.h>
-#endif
 
 #include "arraysize.h"
 #include "build_bug_on.h"

--- a/snis_server.c
+++ b/snis_server.c
@@ -36,11 +36,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <math.h>
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-#include <linux/tcp.h>
-#else
 #include <netinet/tcp.h>
-#endif
 #include <stddef.h>
 #include <stdarg.h>
 #include <limits.h>


### PR DESCRIPTION
Is there a specific reason to use `linux/tcp.h` over `netinet/tcp.h`? If not then we should prefer the latter, as it’s defined by POSIX (and keeps us from having to add OpenBSD, DragonFlyBSD, NetBSD, etc to all the ifdefs).