### PR TITLE
update readme with helpful hint for changelog

### DIFF
--- a/README
+++ b/README
@@ -173,7 +173,9 @@ INSTRUCTIONS FOR BUILDING DEBIAN PACKAGE
 	/place/where/you/cloned/space-nerds-in-space/../snis-version.deb
 
 	In order to get the Git commit messages into the Debian changelog (and bump
-	versions), look at git-buildpackage and git-dch
+	versions), look at git-buildpackage and git-dch. A handy command that will dump
+	the commit hash in shorthand, with the subject content, is:
+	`git log --pretty=format:"  * %h %s"`
 
 *Note: I have doubts that just essentially dumping "git log --oneline" output into
        the Debian changelog is really the right thing to do, though I might


### PR DESCRIPTION
Add helpful hint to generate commit output with formatted double space + asterisk debian changelog format.

For the curious, [this](https://github.com/ProfessorKaos64/SteamOS-Tools-Packaging/blob/brewmaster/build-snis.sh#L98) is the trickery I do with the changelogs of projects that I should include commits with. I may augment it to only include the changelogs since the last specified date I built from.

