### PR TITLE
allow -fcommon for gcc 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -647,7 +647,7 @@ MODELS=${MD}/freighter.stl \
 MYCFLAGS=-DPREFIX=${PREFIX} ${DEBUGFLAG} ${PROFILEFLAG} ${OPTIMIZEFLAG}\
 	--pedantic -Wall ${STOP_ON_WARN} -pthread -std=gnu99 ${RDYNAMIC} \
 	-Wno-extended-offsetof -Wno-gnu-folding-constant $(CFLAGS) -Wvla \
-	-DUSE_SNIS_XWINDOWS_HACKS=${USE_SNIS_XWINDOWS_HACKS}
+	-DUSE_SNIS_XWINDOWS_HACKS=${USE_SNIS_XWINDOWS_HACKS} -fcommon
 GTKCFLAGS:=$(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags gtk+-2.0))
 GTKLDFLAGS:=$(shell $(PKG_CONFIG) --libs gtk+-2.0) $(shell $(PKG_CONFIG) --libs gthread-2.0)
 VORBISFLAGS:=$(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags vorbisfile))


### PR DESCRIPTION
add -fcommon for gcc 10

GCC 10 turned on -fno-common by default, so current code can't be compiled without changes. This is simple workaround for now. Better solution would be to revisit header files.

https://gcc.gnu.org/gcc-10/porting_to.html

Signed-off-by: Tomas Kopecek <tkopecek@redhat.com>