### PR TITLE
Blind attempt to re-debianize SDL changes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,17 @@ Section: games
 Priority: optional
 Maintainer: Iván Sánchez Ortega <ivan@sanchezortega.es>
 Build-Depends: debhelper (>= 10),
- portaudio19-dev, 
+ build-essential,
+ portaudio19-dev,
+ libbsd-dev, 
+ libpng-dev,
  libvorbis-dev,
- libgtk2.0-dev,
- openscad,
- libgtkglext1-dev, 
+ libsdl2-dev,
+ libsdl2-2.0-0,
  liblua5.2-dev,
- libglew-dev (>= 1.10.0-3),
- libsdl1.2-dev
+ libglew1.5-dev,
+ libssl-dev
+Suggests: openscad, git
 Standards-Version: 4.0.0
 Homepage: http://smcameron.github.io/space-nerds-in-space
 Vcs-Git: https://github.com/smcameron/space-nerds-in-space.git
@@ -19,13 +22,17 @@ Vcs-Browser: https://github.com/smcameron/space-nerds-in-space
 Package: snis
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, 
- libportaudio2, libportaudiocpp0,
- libvorbis0a, libvorbisfile3, 
- libgtk2.0-0,
- libgtkglext1,
- liblua5.2-0,
- libglew1.10,
- libsdl1.2debian
+ portaudio19,
+ libbsd, 
+ libpng,
+ libvorbis,
+ libsdl2,
+ libsdl2-2.0-0,
+ liblua5.2,
+ libglew1.5,
+ libssl,
+ libttspico-utils | espeak, 
+ sox | alsa-utils
 Description: Multi-player networked spaceship bridge simulator
  This is a multiplayer networked spaceship bridge simulator game
  inspired by another game called "Artemis Spaceship Bridge Simulator"


### PR DESCRIPTION
This is a blind (i.e. **untested**) attempt to fix #305.

Copy-pasting the package names from https://github.com/smcameron/space-nerds-in-space#step-1-install-dependencies and putting those in the right part of the `debian/control` file *should* be enough.

Alas, I'm not in the best position right not to test if the SNIS `.deb` builds/runs as before the GTK→SDL changes

Signed-off-by: Iván Sánchez Ortega <ivan@sanchezortega.es>


