### PR TITLE
H22

### DIFF
--- a/snis_marshal.c
+++ b/snis_marshal.c
@@ -381,48 +381,50 @@ void packed_buffer_init(struct packed_buffer * pb, void *buffer, int size)
 	pb->buffer_cursor = 0;
 }
 
-uint32_t dtou32(double d, uint32_t scale)
+static uint32_t dtou32(double d, uint32_t scale)
 {
 	return (uint32_t) ((d / scale) * (double) UINT32_MAX);
 }
 
-double u32tod(uint32_t u, uint32_t scale)
+static double u32tod(uint32_t u, uint32_t scale)
 {
 	return ((double) u * (double) scale) / (double) UINT32_MAX;
 }
 
-int32_t dtos32(double d, int32_t scale)
+static int32_t dtos32(double d, int32_t scale)
 {
 	return (int32_t) ((d / scale) * (double) INT32_MAX);
 }
 
+#ifdef TEST_MARSHAL
 /* Q for quaternion */
-int32_t Qtos32(float q)
+static int32_t Qtos32(float q)
 {
 	/* q must be between -1.0 and 1.0 */
 	return (int32_t) (q * (float) (INT32_MAX - 1));
 }
 
 /* Q for quaternion */
-float s32toQ(int32_t i)
+static float s32toQ(int32_t i)
 {
 	return ((float) i) / (float) (INT32_MAX - 1);
 }
+#endif
 
 /* Q for quaternion */
-int16_t Qtos16(float q)
+static int16_t Qtos16(float q)
 {
 	/* q must be between -1.0 and 1.0 */
 	return (int16_t) (q * (float) (INT16_MAX - 1));
 }
 
 /* Q for quaternion */
-float s16toQ(int16_t i)
+static float s16toQ(int16_t i)
 {
 	return ((float) i) / (float) (INT16_MAX - 1);
 }
 
-double s32tod(int32_t u, int32_t scale)
+static double s32tod(int32_t u, int32_t scale)
 {
 	return ((double) u * (double) scale) / (double) INT32_MAX;
 }

--- a/snis_marshal.c
+++ b/snis_marshal.c
@@ -27,39 +27,19 @@
  */
 #define SNIS_MARSHAL_DETECT_NANS 0
 
-static int host_is_little_endian()
-{
-	static int answer = -1;
-	uint32_t x = 0x01020304;
-	unsigned char *c = (unsigned char *) &x;
-
-	if (answer != -1)
-		return answer;
-
-	answer = (c[0] == 0x04);
-	return answer;
-}
-
 /* change a u64 to network byte order */
 static uint64_t cpu_to_be64(uint64_t v)
 {
-	unsigned char *x, *y;
-	uint64_t answer;
-
-	if (!host_is_little_endian())
-		return v;
-		
-	x = (unsigned char *) &v;
-	y = (unsigned char *) &answer;
-	y[0] = x[7];
-	y[1] = x[6];
-	y[2] = x[5];
-	y[3] = x[4];
-	y[4] = x[3];
-	y[5] = x[2];
-	y[6] = x[1];
-	y[7] = x[0];
-	return answer;
+	/* This works whether the native byte order is big or little endian.  Think about it. */
+	unsigned char *x = (unsigned char *) &v;
+	return	((uint64_t) x[0] << 56) |
+		((uint64_t) x[1] << 48) |
+		((uint64_t) x[2] << 40) |
+		((uint64_t) x[3] << 32) |
+		((uint64_t) x[4] << 24) |
+		((uint64_t) x[5] << 16) |
+		((uint64_t) x[6] << 8) |
+		((uint64_t) x[7] << 0);
 }
 
 static uint64_t be64_to_cpu(uint64_t v)

--- a/snis_marshal.h
+++ b/snis_marshal.h
@@ -6,14 +6,6 @@
 
 #include "quat.h"
 
-#pragma pack(1)
-struct packed_double 
-{
-	int64_t fractional;
-	int32_t exponent;
-};
-#pragma pack()
-
 struct packed_buffer
 {
 	unsigned char *buffer;
@@ -46,7 +38,6 @@ GLOBAL void packed_buffer_free(struct packed_buffer *pb);
  * "q" = u64 (quad word)
  * "s" = string (char *)
  * "r" = raw (char *) (unsigned short len)
- * "d" = double
  * "S" = 32-bit signed integer encoded double (takes 2 params, double + scale )
  * "U" = 32-bit unsigned integer encoded double (takes 2 params, double + scale )
  * "Q" = 4 16-bit signed integer encoded floats representing a quaternion axis + angle
@@ -64,7 +55,6 @@ GLOBAL int packed_buffer_extract(struct packed_buffer *pb, const char *format, .
 GLOBAL int packed_buffer_extract_va(struct packed_buffer *pb, const char *format,
 					va_list ap);
 GLOBAL struct packed_buffer *packed_buffer_new(const char *format, ...);
-GLOBAL int packed_buffer_append_double(struct packed_buffer *pb, double value);
 GLOBAL int packed_buffer_append_u16(struct packed_buffer *pb, uint16_t value);
 GLOBAL int packed_buffer_append_u8(struct packed_buffer *pb, uint8_t value);
 GLOBAL int packed_buffer_append_u32(struct packed_buffer *pb, uint32_t value);
@@ -74,7 +64,6 @@ GLOBAL uint16_t packed_buffer_extract_u16(struct packed_buffer *pb);
 GLOBAL uint8_t packed_buffer_extract_u8(struct packed_buffer *pb);
 GLOBAL uint32_t packed_buffer_extract_u32(struct packed_buffer *pb);
 GLOBAL uint64_t packed_buffer_extract_u64(struct packed_buffer *pb);
-GLOBAL double packed_buffer_extract_double(struct packed_buffer *pb);
 GLOBAL void packed_buffer_extract_quat(struct packed_buffer *pb, float q[]);
 GLOBAL int packed_buffer_append_string(struct packed_buffer *pb, unsigned char *str, unsigned short len);
 GLOBAL int packed_buffer_extract_string(struct packed_buffer *pb, char *buffer, int buflen);

--- a/snis_marshal.h
+++ b/snis_marshal.h
@@ -80,15 +80,6 @@ GLOBAL void packed_buffer_print(char *label, struct packed_buffer *pb);
 GLOBAL struct packed_buffer *packed_buffer_copy(struct packed_buffer *pb);
 GLOBAL void packed_buffer_init(struct packed_buffer * pb, void *buffer, int size);
 
-GLOBAL uint32_t dtou32(double d, uint32_t scale);
-GLOBAL double u32tod(uint32_t u, uint32_t scale);
-GLOBAL int32_t dtos32(double d, int32_t scale);
-GLOBAL double s32tod(int32_t u, int32_t scale);
-GLOBAL int16_t Qtos16(float q); /* for quaternion elements. (-1.0 <= q <= 1.0) must hold */
-GLOBAL int32_t Qtos32(float q);
-GLOBAL float s16toQ(int16_t i);
-GLOBAL float s32toQ(int32_t i);
-
 GLOBAL int packed_buffer_append_du32(struct packed_buffer *pb, double d, uint32_t scale);
 GLOBAL int packed_buffer_append_ds32(struct packed_buffer *pb, double d, int32_t scale);
 GLOBAL double packed_buffer_extract_du32(struct packed_buffer *pb, uint32_t scale);

--- a/snis_packet.h
+++ b/snis_packet.h
@@ -461,16 +461,6 @@ struct update_flare_packet {
 	uint32_t x, y, z;
 };
 
-struct add_laser_packet {
-	uint8_t opcode;
-	uint32_t id;
-	uint32_t timestamp;
-	uint8_t power;
-	uint8_t wavelength;
-	struct packed_double x, y;
-	struct packed_double vx, vy;
-};
-
 struct delete_object_packet {
 	uint8_t opcode;
 	uint32_t id;
@@ -591,34 +581,6 @@ struct ack_player_packet {
 	uint8_t opcode;
 	uint8_t allowed;
 };
-
-struct pos_ship_packet {
-	uint8_t opcode;
-	uint32_t id;
-	struct packed_double x, y;
-	struct packed_double vx, vy;
-	struct packed_double heading;
-};
-
-struct pos_starbase_packet {
-	uint8_t opcode;
-	uint32_t id;
-	struct packed_double x, y;
-	struct packed_double vx, vy;
-	struct packed_double heading;
-};
-
-struct pos_laser_packet {
-	uint8_t opcode;
-	uint32_t id;
-	struct packed_double x, y;
-};
-
-struct pos_torpedo_packet {
-	uint8_t opcode;
-	uint32_t id;
-	struct packed_double x, y;
-}; 
 
 struct play_sound_packet {
 	uint8_t opcode;


### PR DESCRIPTION
Improve serialization/marshalling code

* Remove unused double packing code
* Rewrite 64-bit int packing code so knowledge of native endianness is not required
* Mark some functions static that are not needed outside snis_marshall.c

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>
