### PR TITLE
add new packages to the install script to support new asset installat…

### DIFF
--- a/util/install_dependencies
+++ b/util/install_dependencies
@@ -28,7 +28,9 @@ apt_min_packages()
 	liblua5.2-dev
 	libglew-dev
 	libttspico-utils
-	sox"
+	sox
+	libcrypt-dev
+	libcurl4-gnutls-dev"
 }
 
 apt_opt_tts_packages()
@@ -185,7 +187,7 @@ yum_install_package()
 
 yum_already_installed()
 {
-	sudo yum info "$1" > /dev/null 2>&1 
+	sudo yum info "$1" > /dev/null 2>&1
 	return $?
 }
 
@@ -256,7 +258,7 @@ main()
 	packages=$("$package_manager"_min_packages)
 	opt_tts_packages=$("$package_manager"_opt_tts_packages)
 	dev_packages=$("$package_manager"_dev_packages)
-	
+
 	intro
 
 	if yn "Proceed? "


### PR DESCRIPTION
Update installation script to include new package requirements

This change resolves issue https://github.com/smcameron/space-nerds-in-space/issues/367 by including new dependencies from snis_update_assets changes to the installation script. Confirmed working on Kali Linux 22 running on ~2014 MacBook Air.

Signed-off-by: Luke Byrnes <ekulbyrnes@gmail.com>