### PR TITLE
Fixes 5 second error on 2nd visit to lobby after we have connected to…

### DIFF
--- a/snis_client.c
+++ b/snis_client.c
@@ -20703,6 +20703,7 @@ static void connect_to_lobby_button_pressed(__attribute__((unused)) void *unused
 	rc = sscanf(net_setup_ui.lobbyportstr, "%d", &lobbyport);
 	if (rc != 1 || use_default_lobby_port)
 		lobbyport = -1; /* let ssgl use default 2914 or $SSGL_PORT if set */
+	done_with_lobby = 0; //without this line 952 will be set wrong if we have connected to a server once already
 	connect_to_lobby();
 }
 


### PR DESCRIPTION
Fixes 5 second error on 2nd visit to lobby after we have connected to a server on the first visit to the lobby

After connection to a server from the looby, then disconnecting, then visiting lobby again, you will get a 'Connecting to Lobby' error if you do not connect to a server before the 5 second thread timeout. Sure, you can still connect, but it is confusing and annoying. This should fix it.

I am not 100% sure, but I think the ship settings (eg: power) are no longer retained. Or maybe that was introduced on a previous commit.

Signed-off-by: vpelss@gmail.com


