### PR TITLE
Flatpak icon launch issue

### DIFF
--- a/share/applications/io.github.smcameron.space-nerds-in-space.desktop
+++ b/share/applications/io.github.smcameron.space-nerds-in-space.desktop
@@ -2,7 +2,7 @@
 Name=Space Nerds in Space
 GenericName=Space Nerds in Space
 Comment=Networked spaceship bridge simulator
-Exec=snis_client --fullscreen
+Exec=snis_client --fullscreen --auto-download-assets
 Icon=io.github.smcameron.space-nerds-in-space.svg
 Terminal=false
 Type=Application


### PR DESCRIPTION
add --auto-download-assets to Exec in io.github.smcameron.space-nerds-in-space.desktop

After flatpak installation the menu icon is missing  --auto-download-assets
On first run, if there are missing assets, eg: mf-cockpit.stl, the Flashing 'Missing Assets Detected' is presented.
For some reason in the flatpak environment, the 'Update Assets' button works, but it does not display the progress text that normally shows, nor does it show the 'Restart Client' button. 
Adding --auto-download-assets quickly eliminates all this confusion.

Note: running flatpak run  io.github.smcameron.space-nerds-in-space does not encounter this issue as it runs /app/bin/snis.sh internally that already includes --auto-download-assets

Signed-off-by: vpelss@gmail.com


