### PR TITLE
SNIS_DB_DIR missing lagging space-nerds-in-space

### DIFF
--- a/util/update_assets_from_launcher.sh
+++ b/util/update_assets_from_launcher.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "$SNIS_DB_DIR" = "" ]
 then
-	SNIS_DB_DIR="$XDG_DATA_HOME"
+	SNIS_DB_DIR="$XDG_DATA_HOME/space-nerds-in-space"
 	if [ "$SNIS_DB_DIR" = "" ]
 	then
 		SNIS_DB_DIR="$HOME/.local/share/space-nerds-in-space"


### PR DESCRIPTION
SNIS_DB_DIR missing lagging space-nerds-in-space

update_assets_from_launcher.sh 
had SNIS_DB_DIR="$XDG_DATA_HOME"
it should be: SNIS_DB_DIR="$XDG_DATA_HOME/space-nerds-in-space"
to match with snis_client.c code.
Because snis_client.c could not see snis_downloading.txt
It would not display the download processing text or show the restart snis_client when downloaded files were complete.
This fixes that issue.

Signed-off-by: vpelss@gmail.com


