### PR TITLE
Add Docker-based build and installation alternative

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:bookworm-slim
+
+LABEL description="Docker image to have Space Nerds In Space ready to play"
+
+# Configure noninteractive apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Dependencies for build scripts
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates build-essential curl make bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user and prepare workspace
+RUN useradd -m snis && mkdir -p /app && chown -R snis:snis /app
+USER snis
+WORKDIR /app
+
+# Clone repository
+RUN git clone --depth 1 https://github.com/smcameron/space-nerds-in-space.git . 
+
+# Install dependencies
+USER root
+# Fix install script by removing sudo (not installed but unnecessary since root) and replace libcurl-dev with a package name compatible with this distro
+RUN sed -e 's/\bsudo\b//g' -e 's/libcurl-dev/libcurl4-openssl-dev/g' ./util/install_dependencies > ./util/install_dependencies_nosudo_fix \
+    && chmod +x ./util/install_dependencies_nosudo_fix
+RUN apt-get update && \
+    yes | ./util/install_dependencies_nosudo_fix && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+USER snis
+
+# Build the game and assets
+RUN mkdir -p ~/.local/share/space-nerds-in-space/ \
+    && make -j$(nproc) \
+    && make models -j$(nproc)
+
+# Set default command
+CMD ["./bin/snis_client"]

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Here's a quick preview of the build instructions detailed below:
 6. Download additional art assets
 7. Restart `snis_client`
 
-
 [Here is a long, boring video demonstrating how to install](https://www.youtube.com/watch?v=tCokfUtZOqw)
+
+Alternatively, if you run on other OS than linux, or if you do not (or cannot) install the necessary dependencies over your whole system, you can build and use a ready to play [Docker](https://www.docker.com/) image. See [Docker Install](#alternative-docker-install)
 
 ## Step 0: Acquire Hardware and OS
 
@@ -301,3 +302,33 @@ slider that controls the thrusters of your ship. Click on it to begin moving for
 
 ![NAVIGATION](doc/images/navigation.png)
 
+## Alternative: Docker install
+### Step 0: Make sure you have Docker installed
+See https://docs.docker.com/engine/install
+
+Additionally, you might want to install **nvidia-container-toolkit** to make use of you NVidia GPU.
+
+### Step 1: Download the Source Code
+
+```bash
+git clone --depth 1 https://github.com/smcameron/space-nerds-in-space.git
+cd space-nerds-in-space
+```
+
+### Step 2: Build the image
+```bash
+docker build -t snis:latest -f Dockerfile .
+```
+
+### Step 3: Run the client
+```bash
+xhost +local:root
+
+docker run --rm -it \
+    --net=host \
+    --gpus all \
+    --device /dev/dri \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    snis:latest
+```


### PR DESCRIPTION
Hello,

I made a simple dockerfile to create a docker image with the game already installed in.
I also updated the Readme to document how to use it.

My use cases were:
1. I do not want to apt install the dependencies over my whole system. (So now everything is inside the container)
2. My friends are not very skilled with Linux, and having a dockerfile makes the installation more reproducible, with much less variation from one machine to another. (I also hope that it would allow them to play from Windows directly, but I haven't got the opportunity to test it so far)

Cheers,
EtienneAr